### PR TITLE
ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ helm-package: cr helm-chart
 	$(CR) package ./charts/awx-operator
 
 # List all tags oldest to newest.
-TAGS := $(shell git tag -l  --sort=creatordate)
+TAGS := $(shell git ls-remote --tags --sort=version:refname --refs -q | cut -d/ -f3)
 
 # The actual release happens in ansible/helm-release.yml
 # until https://github.com/helm/chart-releaser/issues/122 happens


### PR DESCRIPTION
##### SUMMARY
Due to how the build process checks out the repository all tags are not available when the index is going to be updated.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
These are the only tags in the shallow checkout.
```bash
$ git tag -l  --sort=creatordate
0.6.0
0.7.0
0.8.0
0.9.0
0.10.0
0.11.0
0.12.0
0.13.0
0.14.0
0.15.0
0.16.0
0.16.1
0.30.0
```
New metod queries the remote instead.
```bash
$ git ls-remote --tags --sort=version:refname --refs -q | cut -d/ -f3
0.6.0
0.7.0
0.8.0
0.9.0
0.10.0
0.11.0
0.12.0
0.13.0
0.14.0
0.15.0
0.16.0
0.16.1
0.17.0
0.18.0
0.19.0
0.20.0
0.20.1
0.20.2
0.21.0
0.22.0
0.23.0
0.24.0
0.25.0
0.26.0
0.27.0
0.28.0
0.29.0
0.30.0
```